### PR TITLE
fix(PhotoLabs): update demo video format to `webm` from `mp4`

### DIFF
--- a/app/components/Projects.tsx
+++ b/app/components/Projects.tsx
@@ -103,7 +103,7 @@ const projectsData = [
   {
     id: 6,
     title: '🖼️ PhotoLabs',
-    demoVideo: '/images/demos/PhotoLabs_Demo_Video.mp4',
+    demoVideo: '/images/demos/PhotoLabs_Demo_Video.webm',
     gitUrl: 'https://github.com/kazvee/photolabs/#readme',
     description: 'Stock Photo browsing app',
     tools:


### PR DESCRIPTION
The timing of the subtitles is correct only during the first playthrough of the `.mp4` file for PhotoLabs. When replaying the video, the first few seconds are cut off. Since the `.webm` format does not have this issue, we will use it for the demo video instead.